### PR TITLE
python3 classes

### DIFF
--- a/color_helper_insert.py
+++ b/color_helper_insert.py
@@ -4,7 +4,7 @@ from ColorHelper.lib import csscolors
 import ColorHelper.color_helper_util as util
 
 
-class InsertionCalc(object):
+class InsertionCalc:
     """Calculate and insert color."""
 
     def __init__(self, view, point, target_color, convert=None):

--- a/lib/ase.py
+++ b/lib/ase.py
@@ -85,7 +85,7 @@ def format_byte_size(fmt):
     return b
 
 
-class _Writer(object):
+class _Writer:
     """ASE writer."""
 
     def __init__(self, ase):
@@ -167,7 +167,7 @@ class _Writer(object):
         self.bin.close()
 
 
-class _Reader(object):
+class _Reader:
     """ASE reader."""
 
     def __init__(self, ase, byte_string=False):

--- a/lib/file_strip/comments.py
+++ b/lib/file_strip/comments.py
@@ -115,7 +115,7 @@ class CommentException(Exception):
         return repr(self.value)
 
 
-class Comments(object):
+class Comments:
     """Comment strip class."""
 
     styles = []

--- a/lib/rgba.py
+++ b/lib/rgba.py
@@ -17,7 +17,7 @@ def clamp(value, mn, mx):
     return max(min(value, mx), mn)
 
 
-class RGBA(object):
+class RGBA:
     """RGBA object for converting between color formats or applying filters to the color."""
 
     r = None

--- a/tests/validate_json_format.py
+++ b/tests/validate_json_format.py
@@ -70,7 +70,7 @@ VIOLATION_MSG = {
 }
 
 
-class CheckJsonFormat(object):
+class CheckJsonFormat:
     """
     Test JSON for format irregularities.
 


### PR DESCRIPTION
Since you target ST3 only, which means python3 only. You don't need to explicitly inherit from `object`, all classes implicitly inherit from `object` in python3.