### PR TITLE
Support for Stylus-lang

### DIFF
--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -137,7 +137,7 @@
                 // Based on https://github.com/billymoon/Stylus/blob/master/Stylus.tmLanguage
                 "constant.other.color.rgb-value.stylus",
                 "constant.color.w3c-standard-color-name.stylus",
-                "meta.property-value.stylus",
+                "meta.property-value.stylus"
             ],
             "allowed_colors": ["css3"],
             "extensions": [],

--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -128,6 +128,21 @@
             "extensions": [".tmTheme"],
             "use_hex_argb": false,
             "compress_hex_output": false
+        },
+        {
+            "syntax_files": [],
+            "syntax_filter": "whitelist",
+            "base_scopes": ["source.stylus"],
+            "scan_scopes": [
+                // Based on https://github.com/billymoon/Stylus/blob/master/Stylus.tmLanguage
+                "constant.other.color.rgb-value.stylus",
+                "constant.color.w3c-standard-color-name.stylus",
+                "meta.property-value.stylus",
+            ],
+            "allowed_colors": ["css3"],
+            "extensions": [],
+            "use_hex_argb": false,
+            "compress_hex_output": true
         }
     ],
 


### PR DESCRIPTION
**Summary**

Adds support so it works with `.stylus` and `.styl` files as well. `scan_scopes` obtained from https://github.com/billymoon/Stylus.