### PR TITLE
Added toggle support for left/right positioned previews

### DIFF
--- a/color_helper.py
+++ b/color_helper.py
@@ -72,6 +72,9 @@ def start_file_index(view):
                     if s.get('show_index_status', True):
                         sublime.status_message('File color indexer started...')
 
+def preview_is_on_left():
+    """Return boolean for positioning preview on left/right"""
+    return ch_settings.get('preview_position') != 'right'
 
 ###########################
 # Main Code
@@ -1122,8 +1125,8 @@ class ChPreview(object):
                 for m in util.COLOR_RE.finditer(text):
                     src_start = src.begin() + m.start(0)
                     src_end = src.begin() + m.end(0)
-                    POSITION_ON_LEFT = False
-                    pt = src_start if POSITION_ON_LEFT else src_end
+                    position_on_left = preview_is_on_left()
+                    pt = src_start if position_on_left else src_end
                     if str(pt) in preview:
                         continue
                     elif not visible_region.contains(sublime.Region(src.begin() + m.start(0), src.begin() + m.end(0))):
@@ -1243,6 +1246,7 @@ class ChPreview(object):
             #    - hash result is wrong
             # Update preview meta data with new results
             old_preview = view.settings().get('color_helper.preview_meta', {})
+            position_on_left = preview_is_on_left()
             preview = {}
             for k, v in old_preview.items():
                 phantoms = mdpopups.query_phantom(view, v[4])
@@ -1250,9 +1254,8 @@ class ChPreview(object):
                 if pt is None:
                     mdpopups.erase_phantom_by_id(view, v[4])
                 else:
-                    POSITION_ON_LEFT = False
-                    color_start = pt if POSITION_ON_LEFT else pt - v[1]
-                    color_end = pt + v[1] if POSITION_ON_LEFT else pt
+                    color_start = pt if position_on_left else pt - v[1]
+                    color_end = pt + v[1] if position_on_left else pt
                     approx_color_start = color_start - 5
                     if approx_color_start < 0:
                         approx_color_start = 0

--- a/color_helper.py
+++ b/color_helper.py
@@ -1251,23 +1251,22 @@ class ChPreview(object):
                     mdpopups.erase_phantom_by_id(view, v[4])
                 else:
                     POSITION_ON_LEFT = False
-                    match_start = pt - v[1]
-                    approx_color_start = pt - 5 if POSITION_ON_LEFT else pt - v[1] - 5
+                    color_start = pt if POSITION_ON_LEFT else pt - v[1]
+                    color_end = pt + v[1] if POSITION_ON_LEFT else pt
+                    approx_color_start = color_start - 5
                     if approx_color_start < 0:
                         approx_color_start = 0
-                    approx_color_end = pt + v[1] + 5 if POSITION_ON_LEFT else pt + 5
+                    approx_color_end = color_end + 5
                     if approx_color_end > view.size():
                         approx_color_end = view.size()
                     text = view.substr(sublime.Region(approx_color_start, approx_color_end))
                     m = util.COLOR_RE.search(text)
-                    color_start = approx_color_start + 5
-                    color_end = (approx_color_end - 5) - 1
                     if (
                         not m or
                         not m.group(v[2]) or
                         start + m.start(0) != color_start or
                         hash(m.group(0)) != v[0] or
-                        v[3] != hash(view.scope_name(color_start) + ':' + view.scope_name(color_end))
+                        v[3] != hash(view.scope_name(color_start) + ':' + view.scope_name(color_end - 1))
                     ):
                         mdpopups.erase_phantom_by_id(view, v[4])
                     else:

--- a/color_helper.py
+++ b/color_helper.py
@@ -1122,8 +1122,8 @@ class ChPreview(object):
                 for m in util.COLOR_RE.finditer(text):
                     src_start = src.begin() + m.start(0)
                     src_end = src.begin() + m.end(0)
-                    my_option = True
-                    pt = src_start if my_option else src_end
+                    POSITION_ON_LEFT = False
+                    pt = src_start if POSITION_ON_LEFT else src_end
                     if str(pt) in preview:
                         continue
                     elif not visible_region.contains(sublime.Region(src.begin() + m.start(0), src.begin() + m.end(0))):
@@ -1246,14 +1246,18 @@ class ChPreview(object):
             preview = {}
             for k, v in old_preview.items():
                 phantoms = mdpopups.query_phantom(view, v[4])
+                print(phantoms)
                 pt = phantoms[0].begin() if phantoms else None
                 if pt is None:
                     mdpopups.erase_phantom_by_id(view, v[4])
                 else:
-                    start = pt - 5
+                    POSITION_ON_LEFT = False
+                    match_start = pt - v[1]
+                    match_end = pt + v[1] # TODO: Shouldn't this be + 1 or -1 like src_end?
+                    start = pt - 5 if POSITION_ON_LEFT else pt + v[1] - 5
                     if start < 0:
                         start = 0
-                    end = pt + v[1] + 5
+                    end = pt + v[1] + 5 if POSITION_ON_LEFT else pt + 5
                     if end > view.size():
                         end = view.size()
                     text = view.substr(sublime.Region(start, end))
@@ -1261,9 +1265,9 @@ class ChPreview(object):
                     if (
                         not m or
                         not m.group(v[2]) or
-                        start + m.start(0) != pt or
+                        start + m.start(0) != match_start or
                         hash(m.group(0)) != v[0] or
-                        v[3] != hash(view.scope_name(pt) + ':' + view.scope_name(pt + v[1] - 1))
+                        v[3] != hash(view.scope_name(match_start) + ':' + view.scope_name(pt - 1))
                     ):
                         mdpopups.erase_phantom_by_id(view, v[4])
                     else:

--- a/color_helper.py
+++ b/color_helper.py
@@ -1265,7 +1265,7 @@ class ChPreview(object):
                         not m.group(v[2]) or
                         start + m.start(0) != (pt if POSITION_ON_LEFT else match_start) or
                         hash(m.group(0)) != v[0] or
-                        v[3] != hash(view.scope_name((pt if POSITION_ON_LEFT else match_start)) + ':' + view.scope_name((pt + v[1] - 1 if POSITION_ON_LEFT else pt -1))
+                        v[3] != hash(view.scope_name((pt if POSITION_ON_LEFT else match_start)) + ':' + view.scope_name((pt + v[1] - 1 if POSITION_ON_LEFT else pt - 1)))
                     ):
                         mdpopups.erase_phantom_by_id(view, v[4])
                     else:

--- a/color_helper.py
+++ b/color_helper.py
@@ -1250,11 +1250,10 @@ class ChPreview(object):
                 if pt is None:
                     mdpopups.erase_phantom_by_id(view, v[4])
                 else:
-                    match_start = pt - v[1]
-                    start = match_start - 5
+                    start = pt - 5
                     if start < 0:
                         start = 0
-                    end = pt + 5
+                    end = pt + v[1] + 5
                     if end > view.size():
                         end = view.size()
                     text = view.substr(sublime.Region(start, end))
@@ -1262,9 +1261,9 @@ class ChPreview(object):
                     if (
                         not m or
                         not m.group(v[2]) or
-                        start + m.start(0) != match_start or
+                        start + m.start(0) != pt or
                         hash(m.group(0)) != v[0] or
-                        v[3] != hash(view.scope_name(match_start) + ':' + view.scope_name(pt - 1))
+                        v[3] != hash(view.scope_name(pt) + ':' + view.scope_name(pt + v[1] - 1))
                     ):
                         mdpopups.erase_phantom_by_id(view, v[4])
                     else:

--- a/color_helper.py
+++ b/color_helper.py
@@ -74,7 +74,7 @@ def start_file_index(view):
 
 def preview_is_on_left():
     """Return boolean for positioning preview on left/right"""
-    return ch_settings.get('preview_position') != 'right'
+    return ch_settings.get('inline_preview_position') != 'right'
 
 ###########################
 # Main Code

--- a/color_helper.py
+++ b/color_helper.py
@@ -72,9 +72,11 @@ def start_file_index(view):
                     if s.get('show_index_status', True):
                         sublime.status_message('File color indexer started...')
 
+
 def preview_is_on_left():
-    """Return boolean for positioning preview on left/right"""
+    """Return boolean for positioning preview on left/right."""
     return ch_settings.get('inline_preview_position') != 'right'
+
 
 ###########################
 # Main Code

--- a/color_helper.py
+++ b/color_helper.py
@@ -1252,20 +1252,22 @@ class ChPreview(object):
                 else:
                     POSITION_ON_LEFT = False
                     match_start = pt - v[1]
-                    start = pt - 5 if POSITION_ON_LEFT else match_start - 5
-                    if start < 0:
-                        start = 0
-                    end = pt + v[1] + 5 if POSITION_ON_LEFT else pt + 5
-                    if end > view.size():
-                        end = view.size()
-                    text = view.substr(sublime.Region(start, end))
+                    fuzzy_color_start = pt - 5 if POSITION_ON_LEFT else match_start - 5
+                    if fuzzy_color_start < 0:
+                        fuzzy_color_start = 0
+                    fuzzy_color_end = pt + v[1] + 5 if POSITION_ON_LEFT else pt + 5
+                    if fuzzy_color_end > view.size():
+                        fuzzy_color_end = view.size()
+                    text = view.substr(sublime.Region(fuzzy_color_start, fuzzy_color_end))
                     m = util.COLOR_RE.search(text)
+                    color_start = pt if POSITION_ON_LEFT else match_start
+                    color_end = pt + v[1] - 1 if POSITION_ON_LEFT else pt - 1
                     if (
                         not m or
                         not m.group(v[2]) or
-                        start + m.start(0) != (pt if POSITION_ON_LEFT else match_start) or
+                        start + m.start(0) != color_start or
                         hash(m.group(0)) != v[0] or
-                        v[3] != hash(view.scope_name((pt if POSITION_ON_LEFT else match_start)) + ':' + view.scope_name((pt + v[1] - 1 if POSITION_ON_LEFT else pt - 1)))
+                        v[3] != hash(view.scope_name(color_start) + ':' + view.scope_name(color_end))
                     ):
                         mdpopups.erase_phantom_by_id(view, v[4])
                     else:

--- a/color_helper.py
+++ b/color_helper.py
@@ -1120,7 +1120,11 @@ class ChPreview(object):
             for src in source:
                 text = view.substr(src)
                 for m in util.COLOR_RE.finditer(text):
-                    if str(src.begin() + m.end(0)) in preview:
+                    src_start = src.begin() + m.start(0)
+                    src_end = src.begin() + m.end(0)
+                    my_option = True
+                    pt = src_start if my_option else src_end
+                    if str(pt) in preview:
                         continue
                     elif not visible_region.contains(sublime.Region(src.begin() + m.start(0), src.begin() + m.end(0))):
                         continue
@@ -1181,14 +1185,13 @@ class ChPreview(object):
                     color, alpha, alpha_dec = util.translate_color(m, use_hex_argb)
                     color += alpha if alpha is not None else 'ff'
                     no_alpha_color = color[:-2] if len(color) > 7 else color
-                    pt = src.begin() + m.end(0)
                     scope = view.scope_name(pt)
-                    start_scope = view.scope_name(src.begin() + m.start(0))
-                    end_scope = view.scope_name(src.begin() + m.end(0) - 1)
+                    start_scope = view.scope_name(src_start)
+                    end_scope = view.scope_name(src_end - 1)
                     rgba = RGBA(mdpopups.scope2style(view, scope)['background'])
                     rgba.invert()
                     color = '<a href="%d">%s</a>' % (
-                        src.begin() + m.start(0),
+                        pt,
                         mdpopups.color_box(
                             [no_alpha_color, color], rgba.get_rgb(),
                             height=box_height, width=box_height,

--- a/color_helper.py
+++ b/color_helper.py
@@ -1120,7 +1120,7 @@ class ChPreview(object):
             for src in source:
                 text = view.substr(src)
                 for m in util.COLOR_RE.finditer(text):
-                    if str(src.begin() + m.start(0)) in preview:
+                    if str(src.begin() + m.end(0)) in preview:
                         continue
                     elif not visible_region.contains(sublime.Region(src.begin() + m.start(0), src.begin() + m.end(0))):
                         continue
@@ -1181,14 +1181,14 @@ class ChPreview(object):
                     color, alpha, alpha_dec = util.translate_color(m, use_hex_argb)
                     color += alpha if alpha is not None else 'ff'
                     no_alpha_color = color[:-2] if len(color) > 7 else color
-                    pt = src.begin() + m.start(0)
+                    pt = src.begin() + m.end(0)
                     scope = view.scope_name(pt)
-                    start_scope = view.scope_name(pt)
+                    start_scope = view.scope_name(src.begin() + m.start(0))
                     end_scope = view.scope_name(src.begin() + m.end(0) - 1)
                     rgba = RGBA(mdpopups.scope2style(view, scope)['background'])
                     rgba.invert()
                     color = '<a href="%d">%s</a>' % (
-                        pt,
+                        src.begin() + m.start(0),
                         mdpopups.color_box(
                             [no_alpha_color, color], rgba.get_rgb(),
                             height=box_height, width=box_height,
@@ -1247,10 +1247,11 @@ class ChPreview(object):
                 if pt is None:
                     mdpopups.erase_phantom_by_id(view, v[4])
                 else:
-                    start = pt - 5
+                    match_start = pt - v[1]
+                    start = match_start - 5
                     if start < 0:
                         start = 0
-                    end = pt + v[1] + 5
+                    end = pt + 5
                     if end > view.size():
                         end = view.size()
                     text = view.substr(sublime.Region(start, end))
@@ -1258,9 +1259,9 @@ class ChPreview(object):
                     if (
                         not m or
                         not m.group(v[2]) or
-                        start + m.start(0) != pt or
+                        start + m.start(0) != match_start or
                         hash(m.group(0)) != v[0] or
-                        v[3] != hash(view.scope_name(pt) + ':' + view.scope_name(pt + v[1] - 1))
+                        v[3] != hash(view.scope_name(match_start) + ':' + view.scope_name(pt - 1))
                     ):
                         mdpopups.erase_phantom_by_id(view, v[4])
                     else:

--- a/color_helper.py
+++ b/color_helper.py
@@ -1246,15 +1246,13 @@ class ChPreview(object):
             preview = {}
             for k, v in old_preview.items():
                 phantoms = mdpopups.query_phantom(view, v[4])
-                print(phantoms)
                 pt = phantoms[0].begin() if phantoms else None
                 if pt is None:
                     mdpopups.erase_phantom_by_id(view, v[4])
                 else:
                     POSITION_ON_LEFT = False
                     match_start = pt - v[1]
-                    match_end = pt + v[1] # TODO: Shouldn't this be + 1 or -1 like src_end?
-                    start = pt - 5 if POSITION_ON_LEFT else pt + v[1] - 5
+                    start = pt - 5 if POSITION_ON_LEFT else match_start - 5
                     if start < 0:
                         start = 0
                     end = pt + v[1] + 5 if POSITION_ON_LEFT else pt + 5
@@ -1265,9 +1263,9 @@ class ChPreview(object):
                     if (
                         not m or
                         not m.group(v[2]) or
-                        start + m.start(0) != match_start or
+                        start + m.start(0) != (pt if POSITION_ON_LEFT else match_start) or
                         hash(m.group(0)) != v[0] or
-                        v[3] != hash(view.scope_name(match_start) + ':' + view.scope_name(pt - 1))
+                        v[3] != hash(view.scope_name((pt if POSITION_ON_LEFT else match_start)) + ':' + view.scope_name((pt + v[1] - 1 if POSITION_ON_LEFT else pt -1))
                     ):
                         mdpopups.erase_phantom_by_id(view, v[4])
                     else:

--- a/color_helper.py
+++ b/color_helper.py
@@ -1264,7 +1264,7 @@ class ChPreview(object):
                     if (
                         not m or
                         not m.group(v[2]) or
-                        start + m.start(0) != color_start or
+                        approx_color_start + m.start(0) != color_start or
                         hash(m.group(0)) != v[0] or
                         v[3] != hash(view.scope_name(color_start) + ':' + view.scope_name(color_end - 1))
                     ):

--- a/color_helper.py
+++ b/color_helper.py
@@ -1252,16 +1252,16 @@ class ChPreview(object):
                 else:
                     POSITION_ON_LEFT = False
                     match_start = pt - v[1]
-                    fuzzy_color_start = pt - 5 if POSITION_ON_LEFT else match_start - 5
-                    if fuzzy_color_start < 0:
-                        fuzzy_color_start = 0
-                    fuzzy_color_end = pt + v[1] + 5 if POSITION_ON_LEFT else pt + 5
-                    if fuzzy_color_end > view.size():
-                        fuzzy_color_end = view.size()
-                    text = view.substr(sublime.Region(fuzzy_color_start, fuzzy_color_end))
+                    approx_color_start = pt - 5 if POSITION_ON_LEFT else pt - v[1] - 5
+                    if approx_color_start < 0:
+                        approx_color_start = 0
+                    approx_color_end = pt + v[1] + 5 if POSITION_ON_LEFT else pt + 5
+                    if approx_color_end > view.size():
+                        approx_color_end = view.size()
+                    text = view.substr(sublime.Region(approx_color_start, approx_color_end))
                     m = util.COLOR_RE.search(text)
-                    color_start = pt if POSITION_ON_LEFT else match_start
-                    color_end = pt + v[1] - 1 if POSITION_ON_LEFT else pt - 1
+                    color_start = approx_color_start + 5
+                    color_end = (approx_color_end - 5) - 1
                     if (
                         not m or
                         not m.group(v[2]) or

--- a/color_helper.py
+++ b/color_helper.py
@@ -1196,7 +1196,7 @@ class ChPreview(object):
                     rgba = RGBA(mdpopups.scope2style(view, scope)['background'])
                     rgba.invert()
                     color = '<a href="%d">%s</a>' % (
-                        pt,
+                        src_start,
                         mdpopups.color_box(
                             [no_alpha_color, color], rgba.get_rgb(),
                             height=box_height, width=box_height,

--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -34,6 +34,10 @@
     // Please use either a positive or negative number.
     "inline_preview_offset": 0,
 
+    // Adjust the position of inline image previews.
+    // (left|right)
+    "inline_preview_position": "left",
+
     // Enable color picker option.  Will use native color picker
     // unless "use_color_picker_package" is enabled and external
     // package is installed.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,16 @@ ColorHelper does it best to calculate the correct size for inline images, but wi
 
 If you need to set this per OS or per host, you can via [multiconf](#multiconf).
 
+### inline_preview_position
+
+Previews can be positioned to the left or right of a color. Set this value to "left" or "right to toggle its behavior.
+
+```js
+    // Adjust the position of inline image previews.
+    // (left|right)
+    "inline_preview_position": "left",
+```
+
 ### upper_case_hex
 When inserting a color from the tooltip, this setting will determine if hex colors get uppercased or lowercased.
 


### PR DESCRIPTION
As discussed in #64, adding left/right positioning support solves cursor jump issues. In this PR:
- Added toggle support via `inline_preview_position`
- Added clarified variables (we can remove these if desired but they helped me understand initial intentions of code)
- Fixes #64 

**Notes:**

I haven't squashed this branch as GitHub now supports squashing commits. If you would like me to still squash it (e.g. to merge outside of GitHub), I'm fine with doing that.
