### PR TITLE
Improve: Use the newer API for opening settings

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -13,18 +13,11 @@
                         "children":
                         [
                             {
-                                "command": "open_file", "args":
-                                {
-                                    "file": "${packages}/ColorHelper/color_helper.sublime-settings"
-                                },
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file", "args":
-                                {
-                                    "file": "${packages}/User/color_helper.sublime-settings"
-                                },
-                                "caption": "Settings – User"
+                                "caption": "Settings",
+                                "command": "edit_settings",
+                                "args": {
+                                  "base_file": "${packages}/ColorHelper/color_helper.sublime-settings",
+                                  "default": "// Settings in here override those in \"ColorHelper/color_helper.sublime-settings\",\n\n{\n\t$0\n}\n"}
                             },
                             { "caption": "-" },
                             {


### PR DESCRIPTION
This will open default and user settings side by side
closes #77

I had some trouble setting up test locally but I committed and make a PR so the test can run on Travis

```
$ ./run_tests.sh
======================================= test session starts =======================================
platform darwin -- Python 3.5.0a2, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /Users/simon/Library/Application Support/Sublime Text 3/Packages/ColorHelper, inifile:
collected 1 items

tests/test_json.py .

==================================== 1 passed in 0.34 seconds =====================================
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/plugins/manager.py", line 175, in load_plugin
    self._load(verify_requirements)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/plugins/manager.py", line 147, in _load
    self._plugin = resolve()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2316, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/plugins/pyflakes.py", line 15, in <module>
    import pyflakes.checker
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pyflakes/checker.py", line 62, in <module>
    LOOP_TYPES = (ast.While, ast.For, ast.AsyncFor)
AttributeError: module 'ast' has no attribute 'AsyncFor'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/bin/flake8", line 11, in <module>
    sys.exit(main())
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/main/cli.py", line 16, in main
    app.run(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/main/application.py", line 322, in run
    self._run(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/main/application.py", line 305, in _run
    self.initialize(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/main/application.py", line 295, in initialize
    self.find_plugins()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/main/application.py", line 147, in find_plugins
    self.check_plugins.load_plugins()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/plugins/manager.py", line 392, in load_plugins
    plugins = list(self.manager.map(load_plugin))
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/plugins/manager.py", line 284, in map
    yield func(self.plugins[name], *args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/plugins/manager.py", line 390, in load_plugin
    return plugin.load_plugin()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/flake8/plugins/manager.py", line 183, in load_plugin
    raise failed_to_load
flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "F" due to module 'ast' has no attribute 'AsyncFor'.```