### PR TITLE
Adds basic support for LESS files

### DIFF
--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -171,6 +171,20 @@
             "extensions": [],
             "use_hex_argb": false,
             "compress_hex_output": true
+        },
+        {
+            "syntax_files": [],
+            "syntax_filter": "whitelist",
+            "base_scopes": ["source.less"],
+            "scan_scopes": [
+                "constant.other.color.rgb-value.css",
+                "constant.color.w3c-standard-color-name.css",
+                "meta.property-value.css"
+            ],
+            "allowed_colors": ["css3"],
+            "extensions": [],
+            "use_hex_argb": false,
+            "compress_hex_output": true
         }
     ],
 


### PR DESCRIPTION
This is the same config as stylus, with the scopes using `css` instead of `stylus`.