### PR TITLE
Fix color scope for Sass package

### DIFF
--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -125,7 +125,7 @@
                 // Sass and SCSS (based on: https://packagecontrol.io/packages/Syntax%20Highlighting%20for%20Sass)
                 "meta.property-list.css.sass -comment -string",
                 // Sass (based on https://packagecontrol.io/packages/Syntax%20Highlighting%20for%20PostCSS)
-                "constant.other.rgb-value.sass -comment -string",
+                "constant.other.color.rgb-value.css.sass -comment -string",
                 // SCSS (based on https://packagecontrol.io/packages/SCSS)
                 "constant.other.color.rgb-value.scss -comment -string",
                 // SCSS (based on https://packagecontrol.io/packages/SCSS)


### PR DESCRIPTION
The [Sass](https://github.com/P233/Syntax-highlighting-for-Sass) package has revised the color scope hence this PR.

- https://github.com/P233/Syntax-highlighting-for-Sass/blob/master/Syntaxes/SCSS.sublime-syntax#L149-L151
- https://github.com/P233/Syntax-highlighting-for-Sass/blob/master/Syntaxes/Sass.sublime-syntax#L151-L153
