### PR TITLE
Fix inline color phantom makes line height larger a little bit

### DIFF
--- a/color_helper.py
+++ b/color_helper.py
@@ -1200,7 +1200,7 @@ class ChPreview(object):
                     rgba = RGBA(mdpopups.scope2style(view, scope)['background'])
                     rgba.brightness(1.1 if rgba.get_luminance() <= 127 else .9)
                     preview_id = str(time())
-                    color = '<style>html, body {margin: 0; padding:0;}</style><a href="%s">%s</a>' % (
+                    color = '<style>html, body {margin: 0; padding: 0;} a {line-height: 0;}</style><a href="%s">%s</a>' % (
                         preview_id,
                         mdpopups.color_box(
                             [no_alpha_color, color], rgba.get_rgb(),


### PR DESCRIPTION
Not sure how to name this problem but I guess following GIFs speak themselves.

Tested with `inline_preview_offset: 0`, which is the default value.

Before PR:

![before-fix](https://user-images.githubusercontent.com/6594915/62868969-6ec24b00-bd49-11e9-979c-e4fd29b5f572.gif)

After PR:

![after-fix](https://user-images.githubusercontent.com/6594915/62868972-6ff37800-bd49-11e9-9fd1-fdfd16f1c5f4.gif)

---

Users can use a negative `inline_preview_offset` to kinda fix the problem but I guess it makes sense to have `inline_preview_offset: 0` not making the line height larger.