### PR TITLE
Exclude docs/ directory from packed .sublime-package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/ export-ignore


### PR DESCRIPTION
Would you mind removing the `docs/` directory from the `.sublime-package` to reduce the file size from 735KB to 60KB? `docs/` are not compiled, they are not that useful in the `.sublime-package` imho, but they greatly increase the package size.