### PR TITLE
Color handling

### DIFF
--- a/color_helper.py
+++ b/color_helper.py
@@ -514,8 +514,8 @@ class ColorHelperCommand(sublime_plugin.TextCommand):
         template_vars['hsl_s'] = util.fmt_float(s * 100.0)
         template_vars['hsl_l'] = util.fmt_float(l * 100.0)
         template_vars['hwb_h'] = util.fmt_float(h2 * 360.0)
-        template_vars['hwb_s'] = util.fmt_float(w * 100.0)
-        template_vars['hwb_l'] = util.fmt_float(b * 100.0)
+        template_vars['hwb_w'] = util.fmt_float(w * 100.0)
+        template_vars['hwb_b'] = util.fmt_float(b * 100.0)
 
         s = sublime.load_settings('color_helper.sublime-settings')
         show_global_palettes = s.get('enable_global_user_palettes', True)

--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -91,7 +91,7 @@
             ],
             "scan_completion_scopes": [],
             "extensions": [],
-            "allowed_colors": ["css3"],
+            "allowed_colors": ["css4"],
             "use_hex_argb": false,
             "compress_hex_output": true
         },
@@ -108,7 +108,7 @@
             "scan_completion_scopes": [
             ],
             "extensions": [],
-            "allowed_colors": ["css3"],
+            "allowed_colors": ["css4"],
             "use_hex_argb": false,
             "compress_hex_output": true
         },
@@ -143,7 +143,7 @@
                 "source.sass -comment -string"
             ],
             "extensions": [],
-            "allowed_colors": ["css3"],
+            "allowed_colors": ["css4"],
             "use_hex_argb": false,
             "compress_hex_output": true
         },

--- a/color_helper_picker.py
+++ b/color_helper_picker.py
@@ -411,7 +411,7 @@ class ColorHelperPickerCommand(sublime_plugin.TextCommand):
             self.template_vars['hexa_alpha'] = color[-2:]
         if (
             ('hexa' in self.allowed_colors or 'hexa_compressed') and
-            (self.use_hex_argb is None or self.use_hex_argb is True)
+            (self.use_hex_argb is True)
         ):
             color = '#' + (self.color[-2:] + self.color[1:-2]).lower()
             self.template_vars['ahex_info'] = True

--- a/color_helper_util.py
+++ b/color_helper_util.py
@@ -291,7 +291,7 @@ def translate_color(m, use_hex_argb=False, decode=False):
         color = "#%02x%02x%02x" % (
             int(content[1:2] * 2, 16), int(content[2:3] * 2, 16), int(content[3:] * 2, 16)
         )
-        alpha = content[0:1]
+        alpha = content[0:1] * 2
         alpha_dec = fmt_float(float(int(alpha, 16)) / 255.0, 3)
     elif m.group('hexa_compressed'):
         if decode:
@@ -301,7 +301,7 @@ def translate_color(m, use_hex_argb=False, decode=False):
         color = "#%02x%02x%02x" % (
             int(content[0:1] * 2, 16), int(content[1:2] * 2, 16), int(content[2:3] * 2, 16)
         )
-        alpha = content[3:]
+        alpha = content[3:] * 2
         alpha_dec = fmt_float(float(int(alpha, 16)) / 255.0, 3)
     elif m.group('hex'):
         if decode:

--- a/panels/info.html
+++ b/panels/info.html
@@ -81,12 +81,12 @@
   {%- endif %}
   {%- if plugin.show_hwb_color %}
 [&gt;&gt;&gt;](__convert__:{{plugin.color}}:hwb){: .small}
- <span class="keyword">hwb</span>(<span class="constant numeric">{{plugin.hsl_h}}, {{plugin.hsl_w}}%, {{plugin.hsl_b}}%</span>)
+ <span class="keyword">hwb</span>(<span class="constant numeric">{{plugin.hwb_h}}, {{plugin.hwb_w}}%, {{plugin.hwb_b}}%</span>)
 <br>
   {%- endif %}
   {%- if plugin.show_hwba_color %}
 [&gt;&gt;&gt;](__convert__:{{plugin.color}}:hwba){: .small}
- <span class="keyword">hwb</span>(<span class="constant numeric">{{plugin.hsl_h}}, {{plugin.hsl_w}}%, {{plugin.hsl_b}}%, {{plugin.alpha}}</span>)
+ <span class="keyword">hwb</span>(<span class="constant numeric">{{plugin.hwb_h}}, {{plugin.hwb_w}}%, {{plugin.hwb_b}}%, {{plugin.alpha}}</span>)
 <br>
   {%- endif %}
 {%- endif %}


### PR DESCRIPTION
- Fix compressed hex with alpha handling. #120 
- Fix display of hwb colors
- Enable CSS4 colors (CSS4 isn't really a thing as each component in CSS now has its own spec with a level, but whatever). #118 