### PR TITLE
Let ch_thread go idle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,14 @@
 - **NEW**: Reduce borders and in some cases remove borders around color previews.
 - **NEW**: Allow insertion of colors when there is an active selection.
 - **NEW**: Add option to override the border color used around color previews in the popup.
-- **FIX**: Fix color scope for Sass package.
+- **FIX**: Reduce busy processes when idle.
+- **FIX**: Fixes for SCSS and Sass packages.
 - **FIX**: Fix issue where inline color phantom could make the line height larger.
 - **FIX**: Fix compressed hex with alpha handling.
 - **FIX**: Fix `hwb` display in info dialog.
 - **FIX**: Project palettes not showing up.
-- **FIX**: Fix with compressed hex colors with alpha.
+- **FIX**: Fix for compressed hex colors with alpha.
+- **FIX**: Ensure minimum size of graphics in order to prevent issue where an error is thrown when image size is too small.
 
 # ColorHelper 2.5.1
 

--- a/color_helper.py
+++ b/color_helper.py
@@ -18,6 +18,7 @@ from .color_helper_insert import InsertCalc, PickerInsertCalc
 from .multiconf import get as qualify_settings
 import traceback
 from html.parser import HTMLParser
+from queue import Queue
 
 __pc_name__ = "ColorHelper"
 
@@ -146,6 +147,7 @@ class ColorHelperCommand(sublime_plugin.TextCommand):
         return
         if ch_thread.ignore_all:
             return
+        start_task()
         now = time()
         ch_thread.modified = True
         ch_thread.time = now
@@ -1401,6 +1403,7 @@ class ColorHelperListener(sublime_plugin.EventListener):
             return
 
         if not ch_thread.ignore_all:
+            start_task()
             now = time()
             ch_thread.modified = True
             ch_thread.time = now
@@ -1687,6 +1690,7 @@ class ChThread(threading.Thread):
         """Setup the thread."""
 
         self.reset()
+        self.queue = Queue()
         threading.Thread.__init__(self)
 
     def reset(self):
@@ -1694,6 +1698,7 @@ class ChThread(threading.Thread):
 
         self.wait_time = 0.12
         self.time = time()
+        self.queue = Queue()
         self.modified = False
         self.ignore_all = False
         self.abort = False
@@ -1815,6 +1820,7 @@ class ChThread(threading.Thread):
         """Kill thread."""
 
         self.abort = True
+        self.queue.put(True)
         while self.is_alive():
             pass
         self.reset()
@@ -1822,10 +1828,14 @@ class ChThread(threading.Thread):
     def run(self):
         """Thread loop."""
 
+        task = False
         while not self.abort:
-            if self.modified is True and time() - self.time > self.wait_time:
-                sublime.set_timeout(lambda: self.payload(), 0)
-            sleep(0.5)
+            task = self.queue.get()
+            while task and not self.abort:
+                if self.modified is True and time() - self.time > self.wait_time:
+                    sublime.set_timeout(self.payload, 0)
+                    task = False
+                sleep(0.5)
 
 
 ###########################
@@ -1838,6 +1848,13 @@ def settings_reload():
     reload_flag = True
     ch_last_updated = time()
     setup_previews()
+
+
+def start_task():
+    """Start task."""
+
+    if ch_thread.is_alive():
+        ch_thread.queue.put(True)
 
 
 def setup_previews():


### PR DESCRIPTION
Fixes #121 

We can't ensure ColorHelper goes completely idle as there is no scroll event, so we have to mimic our own by periodically checking if the view moved, but we can ensure `ch_thread` goes idle.