### PR TITLE
Fix the typo

### DIFF
--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -1,4 +1,4 @@
-# About Markdown Popups
+# About ColorHelper
 
 ## ColorHelper
 


### PR DESCRIPTION
I think it should be "About ColorHelper" unless I am missing something. This was looking odd on the website. Btw thanks for this great plugin.