### PR TITLE
Fix typo of color class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # ColorHelper
 
+## 3.3.2
+
+- **FIX**: Fix typo. `0xahex` color class should have been named `0xhex` in the  
+  settings.
+
 ## 3.3.1
 
 - **FIX**: Ensure that contrast related functions are using XYZ with D65 white  

--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -197,7 +197,7 @@
                 {"space": "srgb", "format": {}}
             ]
         },
-        "0xahex": {
+        "0xhex": {
             "class": "ColorHelper.custom.hex_0x.ColorHex",
             "filters": ["srgb"],
             "output": [

--- a/support.py
+++ b/support.py
@@ -5,7 +5,7 @@ import textwrap
 import webbrowser
 import re
 
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 __pc_name__ = 'ColorHelper'
 
 CSS = '''


### PR DESCRIPTION
0xhex should not be named 0xahex as it does not support alpha first.

Ref https://github.com/facelessuser/ColorHelper/issues/180#issuecomment-812009550
