### PR TITLE
Support color codes in ASS/SSA subtitles

### DIFF
--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -211,6 +211,14 @@
             "output": [
                 {"space": "srgb", "format": {"hex": true}}
             ]
+        },
+        // for color codes like `&HAABBGGRR` and `&HBBGGRR`
+        "and_h_abgr": {
+            "class": "ColorHelper.custom.and_h_abgr.ColorAlphaHex",
+            "filters": ["srgb"],
+            "output": [
+                {"space": "srgb", "format": {"upper": true}}
+            ]
         }
     },
 
@@ -379,6 +387,14 @@
                 "constant.color.w3c-standard-color-name.css",
                 "meta.property-value.css"
             ]
+        },
+        {
+            // ASS ( based on: https://packagecontrol.io/packages/Advanced%20Substation%20Alpha%20(ASS) )
+            "name": "ASS",
+            "base_scopes": ["text.ass"],
+            "scanning": ["constant.other.color"],
+            "color_class": "and_h_abgr",
+            "color_trigger": "" // "constant.other.color" scope is already accurate for colors
         }
     ],
 

--- a/custom/and_h_abgr.py
+++ b/custom/and_h_abgr.py
@@ -1,0 +1,73 @@
+"""Custom color that looks for colors of format `&HAABBGGRR` as `#AARRGGBB`."""
+from ColorHelper.lib.coloraide import Color
+from ColorHelper.lib.coloraide import util
+from ColorHelper.lib.coloraide.spaces import _parse
+from ColorHelper.lib.coloraide.spaces.srgb.css import SRGB
+import copy
+import re
+
+
+class AssABGR(SRGB):
+    MATCH = re.compile(r"&H([0-9a-fA-f]{8}|[0-9a-fA-f]{6})\b")
+
+    @classmethod
+    def match(cls, string: str, start: int = 0, fullmatch: bool = True):
+        m = cls.MATCH.match(string, start)
+        if m is not None and (not fullmatch or m.end(0) == len(string)):
+            return cls.split_channels(m.group(1)), m.end(0)
+        return None, None
+
+    @classmethod
+    def translate_channel(cls, channel: int, value: str):
+        if -1 <= channel <= 2:
+            return _parse.norm_hex_channel(value)
+
+    @classmethod
+    def split_channels(cls, color: str):
+        # convert `BBGGRR` to `AABBGGRR`
+        if len(color) == 6:
+            color = "00" + color
+        # deal with `AABBGGRR`
+        if len(color) == 8:
+            return cls.null_adjust(
+                (
+                    cls.translate_channel(0, "#" + color[6:]),  # RR
+                    cls.translate_channel(1, "#" + color[4:6]),  # GG
+                    cls.translate_channel(2, "#" + color[2:4]),  # BB
+                ),
+                1 - cls.translate_channel(-1, "#" + color[:2]),  # AA
+            )
+
+        raise RuntimeError("Something is wrong in code logics.")
+
+    def to_string(self, parent, *, options=None, alpha=None, precision=None, fit=True, **kwargs):
+        options = kwargs
+        a = util.no_nan(self.alpha)
+        show_alpha = alpha is not False and (alpha is True or a < 1.0)
+
+        template = "&H{:02x}{:02x}{:02x}{:02x}" if show_alpha else "&H{:02x}{:02x}{:02x}"
+        if options.get("upper"):
+            template = template.upper()
+
+        # Always fit hex
+        method = None if not isinstance(fit, str) else fit
+        coords = util.no_nan(parent.fit(method=method).coords())
+        if show_alpha:
+            value = template.format(
+                int(util.round_half_up(a * 255.0)),
+                int(util.round_half_up(coords[2] * 255.0)),
+                int(util.round_half_up(coords[1] * 255.0)),
+                int(util.round_half_up(coords[0] * 255.0)),
+            )
+        else:
+            value = template.format(
+                int(util.round_half_up(coords[2] * 255.0)),
+                int(util.round_half_up(coords[1] * 255.0)),
+                int(util.round_half_up(coords[0] * 255.0)),
+            )
+        return value
+
+
+class ColorAlphaHex(Color):
+    CS_MAP = copy.copy(Color.CS_MAP)
+    CS_MAP["srgb"] = AssABGR


### PR DESCRIPTION
## The Goal

I would like to add support for color codes in ASS/SSA subtitles. The color codes are in the forms of `&HAABBGGRR` or `&HBBGGRR` such as `&H80FF0000` or `&HFF0000`. Note that by default alpha=`00` and it means opaque.

Currently, it's done in the https://packagecontrol.io/packages/Advanced%20Substation%20Alpha%20(ASS) side. But it will require users to modify their ColorHelper's settings so it would be better if it can be moved to ColorHelper.

I am willing to change the naming of files and classes. (I don't know how to name them properly actually.)

## References

- https://github.com/jfcherng-sublime/ST-ASS/pull/9