### PR TITLE
Allow loosy ASS/SSA color codes

### DIFF
--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -394,7 +394,7 @@
             "base_scopes": ["text.ass"],
             "scanning": ["constant.other.color"],
             "color_class": "ass_abgr",
-            "color_trigger": "(?i)&h"
+            "color_trigger": "(?i)&h|\\\\[1-4]?c"
         }
     ],
 

--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -394,7 +394,7 @@
             "base_scopes": ["text.ass"],
             "scanning": ["constant.other.color"],
             "color_class": "ass_abgr",
-            "color_trigger": "(?i)&h|\\\\[1-4]?c"
+            "color_trigger": "(?:&H|(?<=\\\\[1-4]c)|(?<=\\\\c))[0-9a-fA-F]"
         }
     ],
 

--- a/custom/ass_abgr.py
+++ b/custom/ass_abgr.py
@@ -10,7 +10,7 @@ import re
 class AssABGR(SRGB):
     """ASS `ABGR` color space."""
 
-    MATCH = re.compile(r"(?:&H|\[1-4]?c)(?P<color>[0-9a-fA-f]{8}|[0-9a-fA-f]{6})\b", re.IGNORECASE)
+    MATCH = re.compile(r"(?P<prefix>&H)?(?P<color>[0-9a-fA-F]{1,8})\b")
 
     @classmethod
     def match(cls, string: str, start: int = 0, fullmatch: bool = True):
@@ -32,9 +32,10 @@ class AssABGR(SRGB):
     def split_channels(cls, color: str):
         """Split string into the appropriate channels."""
 
-        # convert `BBGGRR` to `AABBGGRR`
-        if len(color) == 6:
-            color = "00" + color
+        # convert `RR` / `GGRR` / `BBGGRR` to `AABBGGRR`
+        # consecutive leading 0s can be omitted and the alpha is 00 (opaque) by default
+        color = color.zfill(8)
+
         # deal with `AABBGGRR`
         if len(color) == 8:
             return cls.null_adjust(

--- a/custom/ass_abgr.py
+++ b/custom/ass_abgr.py
@@ -10,7 +10,7 @@ import re
 class AssABGR(SRGB):
     """ASS `ABGR` color space."""
 
-    MATCH = re.compile(r"&H([0-9a-fA-f]{8}|[0-9a-fA-f]{6})\b")
+    MATCH = re.compile(r"(?:&H|\[1-4]?c)([0-9a-fA-f]{8}|[0-9a-fA-f]{6})\b", re.IGNORECASE)
 
     @classmethod
     def match(cls, string: str, start: int = 0, fullmatch: bool = True):

--- a/custom/ass_abgr.py
+++ b/custom/ass_abgr.py
@@ -10,7 +10,7 @@ import re
 class AssABGR(SRGB):
     """ASS `ABGR` color space."""
 
-    MATCH = re.compile(r"(?P<prefix>&H)?(?P<color>[0-9a-fA-F]{1,8})\b")
+    MATCH = re.compile(r"(?P<prefix>&H)?(?P<color>[0-9a-fA-F]{1,8})(?P<suffix>&|\b)")
 
     @classmethod
     def match(cls, string: str, start: int = 0, fullmatch: bool = True):

--- a/custom/ass_abgr.py
+++ b/custom/ass_abgr.py
@@ -10,7 +10,7 @@ import re
 class AssABGR(SRGB):
     """ASS `ABGR` color space."""
 
-    MATCH = re.compile(r"(?:&H|\[1-4]?c)([0-9a-fA-f]{8}|[0-9a-fA-f]{6})\b", re.IGNORECASE)
+    MATCH = re.compile(r"(?:&H|\[1-4]?c)(?P<color>[0-9a-fA-f]{8}|[0-9a-fA-f]{6})\b", re.IGNORECASE)
 
     @classmethod
     def match(cls, string: str, start: int = 0, fullmatch: bool = True):
@@ -18,7 +18,7 @@ class AssABGR(SRGB):
 
         m = cls.MATCH.match(string, start)
         if m is not None and (not fullmatch or m.end(0) == len(string)):
-            return cls.split_channels(m.group(1)), m.end(0)
+            return cls.split_channels(m.group("color")), m.end(0)
         return None, None
 
     @classmethod


### PR DESCRIPTION
Resolves https://github.com/facelessuser/ColorHelper/pull/191#issuecomment-914347303

> \c&H\<bb\>\<g\g>\<rr\>&
> \1c&H\<bb\>\<g\g>\<rr\>&
> \2c&H\<bb\>\<g\g>\<rr\>&
> \3c&H\<bb\>\<g\g>\<rr\>&
> \4c&H\<bb\>\<g\g>\<rr\>&
> 
> Set the color of the following text. The \c tag is an abbreviation of \1c.
> 
> \1c sets the primary fill color.
> \2c sets the secondary fill color. This is only used for pre-highlight in standard karaoke.
> \3c sets the border color.
> \4c sets the shadow color.
> 
