### PR TITLE
Add color rule for JavaScript and JSX syntax

### DIFF
--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -342,12 +342,12 @@
             "name": "JavaScript/JSX",
             "base_scopes": [
                 "source.js",
-                "source.jsx",
+                "source.jsx"
             ],
             "color_class": "css-level-4",
             "scanning": [
                 // Covers single and double quoted strings, as well as template strings
-                "string.quoted",
+                "string.quoted"
             ]
         },
         {

--- a/color_helper.sublime-settings
+++ b/color_helper.sublime-settings
@@ -339,6 +339,18 @@
             ]
         },
         {
+            "name": "JavaScript/JSX",
+            "base_scopes": [
+                "source.js",
+                "source.jsx",
+            ],
+            "color_class": "css-level-4",
+            "scanning": [
+                // Covers single and double quoted strings, as well as template strings
+                "string.quoted",
+            ]
+        },
+        {
             // Setting is experimental, set "enable" to false if false positives are problematic.
             //
             // GraphViz provides limited scoping that limits our ability to identify exactly


### PR DESCRIPTION
### What's changed, and why?

This adds support for colors embedded in strings in the JavaScript and JSX syntaxes. This greatly helps when developing UI using CSS-in-JS systems such as [Stitches](https://stitches.dev) or [Styled Components](https://styled-components.com). Here's an example of this rule in action:

<img width="534" alt="Screenshot 2022-09-28 at 20 06 23" src="https://user-images.githubusercontent.com/605731/192856386-4a96b4c5-9532-44df-a9d8-2d51996c35b1.png">

### Related resources

This should take care of #87.